### PR TITLE
Listen for back button press

### DIFF
--- a/bottomsheet-sample/src/main/java/com/flipboard/bottomsheet/sample/MainActivity.java
+++ b/bottomsheet-sample/src/main/java/com/flipboard/bottomsheet/sample/MainActivity.java
@@ -1,15 +1,15 @@
 package com.flipboard.bottomsheet.sample;
 
+import com.flipboard.bottomsheet.BottomSheetLayout;
+import com.flipboard.bottomsheet.R;
+import com.flipboard.bottomsheet.commons.IntentPickerSheetView;
+
 import android.app.Activity;
 import android.content.Intent;
 import android.os.Bundle;
 import android.view.View;
 import android.widget.Button;
 import android.widget.TextView;
-
-import com.flipboard.bottomsheet.BottomSheetLayout;
-import com.flipboard.bottomsheet.R;
-import com.flipboard.bottomsheet.commons.IntentPickerSheetView;
 
 import java.util.Comparator;
 
@@ -56,19 +56,6 @@ public class MainActivity extends Activity {
                 bottomSheetLayout.showWithSheetView(intentPickerSheet);
             }
         });
-    }
-
-    @Override
-    public void onBackPressed() {
-        if (bottomSheetLayout.isSheetShowing()) {
-            if (bottomSheetLayout.getState() == BottomSheetLayout.State.EXPANDED) {
-                bottomSheetLayout.peekSheet();
-            } else {
-                bottomSheetLayout.dismissSheet();
-            }
-        } else {
-            super.onBackPressed();
-        }
     }
 
 }

--- a/bottomsheet/src/main/java/com/flipboard/bottomsheet/BottomSheetLayout.java
+++ b/bottomsheet/src/main/java/com/flipboard/bottomsheet/BottomSheetLayout.java
@@ -12,6 +12,7 @@ import android.os.Build;
 import android.support.annotation.NonNull;
 import android.util.AttributeSet;
 import android.util.Property;
+import android.view.KeyEvent;
 import android.view.MotionEvent;
 import android.view.VelocityTracker;
 import android.view.View;
@@ -126,6 +127,8 @@ public class BottomSheetLayout extends FrameLayout {
         dimView = new View(getContext());
         dimView.setBackgroundColor(Color.BLACK);
         dimView.setAlpha(0);
+
+        setFocusableInTouchMode(true);
     }
 
     /**
@@ -176,6 +179,35 @@ public class BottomSheetLayout extends FrameLayout {
         super.onLayout(changed, left, top, right, bottom);
         int bottomClip = (int) (getHeight() - Math.ceil(sheetTranslation));
         this.contentClipRect.set(0, 0, getWidth(), bottomClip);
+    }
+
+    @Override
+    public boolean onKeyPreIme(int keyCode, KeyEvent event) {
+        if (keyCode == KeyEvent.KEYCODE_BACK) {
+            if (event.getAction() == KeyEvent.ACTION_DOWN && event.getRepeatCount() == 0) {
+                KeyEvent.DispatcherState state = getKeyDispatcherState();
+                if (state != null) {
+                    state.startTracking(event, this);
+                }
+                return true;
+            } else if (event.getAction() == KeyEvent.ACTION_UP) {
+                KeyEvent.DispatcherState state = getKeyDispatcherState();
+                if (state != null) {
+                    state.handleUpEvent(event);
+                }
+                if (event.isTracking() && !event.isCanceled()) {
+                    if (isSheetShowing()) {
+                        if (getState() == BottomSheetLayout.State.EXPANDED) {
+                            peekSheet();
+                        } else {
+                            dismissSheet();
+                        }
+                    }
+                    return true;
+                }
+            }
+        }
+        return super.onKeyPreIme(keyCode, event);
     }
 
     private void setSheetTranslation(float sheetTranslation) {


### PR DESCRIPTION
Back handling code copied from stock widgets like `AutoCompleteTextView`. Removes the need to listen for `onBackPressed` in the `Activity`. Sample updated to reflect this. Fixes #10.