### PR TITLE
Show proper elevation commons sheets

### DIFF
--- a/bottomsheet-commons/src/main/java/com/flipboard/bottomsheet/commons/IntentPickerSheetView.java
+++ b/bottomsheet-commons/src/main/java/com/flipboard/bottomsheet/commons/IntentPickerSheetView.java
@@ -1,12 +1,15 @@
 package com.flipboard.bottomsheet.commons;
 
+import android.annotation.SuppressLint;
 import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
 import android.graphics.drawable.Drawable;
+import android.os.Build;
 import android.support.annotation.StringRes;
+import android.support.v4.view.ViewCompat;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -24,6 +27,7 @@ import java.util.List;
 
 import flipboard.bottomsheet.commons.R;
 
+@SuppressLint("ViewConstructor")
 public class IntentPickerSheetView extends FrameLayout {
 
     public interface Filter {
@@ -88,6 +92,8 @@ public class IntentPickerSheetView extends FrameLayout {
                 listener.onIntentPicked(concreteIntent);
             }
         });
+
+        ViewCompat.setElevation(this, Util.dp2px(getContext(), 16f));
     }
 
     public void setSortMethod(Comparator<ActivityInfo> sortMethod) {
@@ -110,6 +116,14 @@ public class IntentPickerSheetView extends FrameLayout {
         super.onLayout(changed, left, top, right, bottom);
         float density = getResources().getDisplayMetrics().density;
         appGrid.setNumColumns((int) (getWidth() / (100 * density)));
+    }
+
+    @Override
+    protected void onSizeChanged(int w, int h, int oldw, int oldh) {
+        // Necessary for showing elevation on 5.0+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            setOutlineProvider(new Util.ShadowOutline(w, h));
+        }
     }
 
     private class Adapter extends BaseAdapter {

--- a/bottomsheet-commons/src/main/java/com/flipboard/bottomsheet/commons/MenuSheetView.java
+++ b/bottomsheet-commons/src/main/java/com/flipboard/bottomsheet/commons/MenuSheetView.java
@@ -2,9 +2,11 @@ package com.flipboard.bottomsheet.commons;
 
 import android.annotation.SuppressLint;
 import android.content.Context;
+import android.os.Build;
 import android.support.annotation.MenuRes;
 import android.support.annotation.Nullable;
 import android.support.annotation.StringRes;
+import android.support.v4.view.ViewCompat;
 import android.text.TextUtils;
 import android.view.LayoutInflater;
 import android.view.Menu;
@@ -95,6 +97,8 @@ public class MenuSheetView extends FrameLayout {
         // Set up the title
         titleView = (TextView) findViewById(R.id.title);
         setTitle(title);
+
+        ViewCompat.setElevation(this, Util.dp2px(getContext(), 16f));
     }
 
     /**
@@ -124,6 +128,14 @@ public class MenuSheetView extends FrameLayout {
         if (menuType == GRID) {
             float density = getResources().getDisplayMetrics().density;
             ((GridView) absListView).setNumColumns((int) (getWidth() / (100 * density)));
+        }
+    }
+
+    @Override
+    protected void onSizeChanged(int w, int h, int oldw, int oldh) {
+        // Necessary for showing elevation on 5.0+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            setOutlineProvider(new Util.ShadowOutline(w, h));
         }
     }
 

--- a/bottomsheet-commons/src/main/java/com/flipboard/bottomsheet/commons/Util.java
+++ b/bottomsheet-commons/src/main/java/com/flipboard/bottomsheet/commons/Util.java
@@ -1,7 +1,11 @@
 package com.flipboard.bottomsheet.commons;
 
+import android.annotation.TargetApi;
 import android.content.Context;
+import android.graphics.Outline;
 import android.util.TypedValue;
+import android.view.View;
+import android.view.ViewOutlineProvider;
 
 public class Util {
 
@@ -16,4 +20,23 @@ public class Util {
         return Math.round(px);
     }
 
+    /**
+     * A helper class for providing a shadow on sheets
+     */
+    @TargetApi(21)
+    static class ShadowOutline extends ViewOutlineProvider {
+
+        int width;
+        int height;
+
+        ShadowOutline(int width, int height) {
+            this.width = width;
+            this.height = height;
+        }
+
+        @Override
+        public void getOutline(View view, Outline outline) {
+            outline.setRect(0, 0, width, height);
+        }
+    }
 }


### PR DESCRIPTION
Unfortunately, I can't think of/figure out a way to let BottomSheetLayout handle this itself, but it at least gives us a good example to show. This adds the 16dp elevation on Lollipop+ to sheets (per the material spec) in the commons sheets. Not *thaaat* noticeable since the "light source" is above where the sheet is, but still visible.

Fixes #4 

No shadow | With shadow
--- | ---
![victara_tmolpe23 32-21 3hsweers07042015022918](https://cloud.githubusercontent.com/assets/1361086/8507365/de1fb086-21f4-11e5-8daf-f0604be99789.png) | ![victara_tmolpe23 32-21 3hsweers07042015022115](https://cloud.githubusercontent.com/assets/1361086/8507366/e2ce90b6-21f4-11e5-9f15-76ee0a79568c.png)
