### PR TITLE
Fix black flick

### DIFF
--- a/bottomsheet/src/main/java/com/flipboard/bottomsheet/BottomSheetLayout.java
+++ b/bottomsheet/src/main/java/com/flipboard/bottomsheet/BottomSheetLayout.java
@@ -126,7 +126,7 @@ public class BottomSheetLayout extends FrameLayout {
         touchSlop = viewConfiguration.getScaledTouchSlop();
 
         dimView = new View(getContext());
-        dimView.setBackgroundColor(Color.BLACK);
+        dimView.setBackgroundColor(Color.TRANSPARENT);
         dimView.setAlpha(0);
 
         setFocusableInTouchMode(true);

--- a/bottomsheet/src/main/java/com/flipboard/bottomsheet/BottomSheetLayout.java
+++ b/bottomsheet/src/main/java/com/flipboard/bottomsheet/BottomSheetLayout.java
@@ -589,6 +589,7 @@ public class BottomSheetLayout extends FrameLayout {
      * Dismiss the sheet currently being presented.
      */
     public void dismissSheet() {
+
         dimView.setBackgroundColor(Color.TRANSPARENT);
         if (state == State.HIDDEN) {
             // no-op

--- a/bottomsheet/src/main/java/com/flipboard/bottomsheet/BottomSheetLayout.java
+++ b/bottomsheet/src/main/java/com/flipboard/bottomsheet/BottomSheetLayout.java
@@ -126,7 +126,7 @@ public class BottomSheetLayout extends FrameLayout {
         touchSlop = viewConfiguration.getScaledTouchSlop();
 
         dimView = new View(getContext());
-        dimView.setBackgroundColor(Color.BLACK);
+        dimView.setBackgroundColor(Color.TRANSPARENT);
         dimView.setAlpha(0);
 
         setFocusableInTouchMode(true);
@@ -428,6 +428,14 @@ public class BottomSheetLayout extends FrameLayout {
         if (onSheetStateChangeListener != null) {
             onSheetStateChangeListener.onSheetStateChanged(state);
         }
+
+        switch (state){
+            case HIDDEN:
+                dimView.setBackgroundColor(Color.TRANSPARENT);
+                break;
+            default:
+                dimView.setBackgroundColor(Color.BLACK);
+        }
     }
 
     private boolean hasFullHeightSheet() {
@@ -470,7 +478,6 @@ public class BottomSheetLayout extends FrameLayout {
      * Set the presented sheet to be in a peeked state.
      */
     public void peekSheet() {
-        dimView.setBackgroundColor(Color.BLACK);
         cancelCurrentAnimation();
         setSheetLayerTypeIfEnabled(LAYER_TYPE_HARDWARE);
         ObjectAnimator anim = ObjectAnimator.ofFloat(this, SHEET_TRANSLATION, getPeekSheetTranslation());
@@ -589,8 +596,6 @@ public class BottomSheetLayout extends FrameLayout {
      * Dismiss the sheet currently being presented.
      */
     public void dismissSheet() {
-
-        dimView.setBackgroundColor(Color.TRANSPARENT);
         if (state == State.HIDDEN) {
             // no-op
             return;

--- a/bottomsheet/src/main/java/com/flipboard/bottomsheet/BottomSheetLayout.java
+++ b/bottomsheet/src/main/java/com/flipboard/bottomsheet/BottomSheetLayout.java
@@ -126,7 +126,7 @@ public class BottomSheetLayout extends FrameLayout {
         touchSlop = viewConfiguration.getScaledTouchSlop();
 
         dimView = new View(getContext());
-        dimView.setBackgroundColor(Color.TRANSPARENT);
+        dimView.setBackgroundColor(Color.BLACK);
         dimView.setAlpha(0);
 
         setFocusableInTouchMode(true);
@@ -470,6 +470,7 @@ public class BottomSheetLayout extends FrameLayout {
      * Set the presented sheet to be in a peeked state.
      */
     public void peekSheet() {
+        dimView.setBackgroundColor(Color.BLACK);
         cancelCurrentAnimation();
         setSheetLayerTypeIfEnabled(LAYER_TYPE_HARDWARE);
         ObjectAnimator anim = ObjectAnimator.ofFloat(this, SHEET_TRANSLATION, getPeekSheetTranslation());
@@ -588,6 +589,7 @@ public class BottomSheetLayout extends FrameLayout {
      * Dismiss the sheet currently being presented.
      */
     public void dismissSheet() {
+        dimView.setBackgroundColor(Color.TRANSPARENT);
         if (state == State.HIDDEN) {
             // no-op
             return;


### PR DESCRIPTION
Suppose we have two fragments. ```Fragment A``` and ```Fragment B```. When there is a transition between ```B``` --> ```A```, ```bottomsheet``` flicks with a black screen causing transition seems awful.

```dimView.setBackgroundColor``` must be set to ```Color.TRANSPARENT```.
