### PR TITLE
Added custom peek & fixed touch on sheet view to allow dragging it

### DIFF
--- a/bottomsheet-sample/src/main/java/com/flipboard/bottomsheet/sample/MenuActivity.java
+++ b/bottomsheet-sample/src/main/java/com/flipboard/bottomsheet/sample/MenuActivity.java
@@ -22,6 +22,7 @@ public class MenuActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_menu);
         bottomSheetLayout = (BottomSheetLayout) findViewById(R.id.bottomsheet);
+        bottomSheetLayout.setInterceptContentTouch(false);
         bottomSheetLayout.setPeekOnDismiss(true);
         findViewById(R.id.list_button).setOnClickListener(new View.OnClickListener() {
             @Override
@@ -38,6 +39,8 @@ public class MenuActivity extends AppCompatActivity {
     }
 
     private void showMenuSheet(MenuSheetView.MenuType menuType) {
+        if (bottomSheetLayout.isSheetShowing()) return;
+
         MenuSheetView menuSheetView =
                 new MenuSheetView(MenuActivity.this, menuType, "Create...", new MenuSheetView.OnMenuItemClickListener() {
                     @Override

--- a/bottomsheet/src/main/java/com/flipboard/bottomsheet/BottomSheetLayout.java
+++ b/bottomsheet/src/main/java/com/flipboard/bottomsheet/BottomSheetLayout.java
@@ -88,6 +88,7 @@ public class BottomSheetLayout extends FrameLayout {
     private OnSheetStateChangeListener onSheetStateChangeListener;
     private View dimView;
     private boolean interceptContentTouch = true;
+    private float peek;
 
     /** Snapshot of the touch's y position on a down event */
     private float downY;
@@ -129,6 +130,8 @@ public class BottomSheetLayout extends FrameLayout {
         dimView = new View(getContext());
         dimView.setBackgroundColor(Color.BLACK);
         dimView.setAlpha(0);
+
+        peek = 0; //getHeight() returns 0 at start!
 
         setFocusableInTouchMode(true);
     }
@@ -236,11 +239,11 @@ public class BottomSheetLayout extends FrameLayout {
         return 0;
     }
 
-    public boolean onInterceptTouchEvent(@NonNull MotionEvent ev) {
+    public boolean onInterceptTouchEvent(@NonNull MotionEvent event) {
         if (interceptContentTouch) {
-            return ev.getActionMasked() == MotionEvent.ACTION_DOWN && isSheetShowing();
+            return event.getActionMasked() == MotionEvent.ACTION_DOWN && isSheetShowing();
         } else {
-            return state == State.EXPANDED;
+            return state == State.EXPANDED || event.getY() > (getHeight() - sheetTranslation);
         }
     }
 
@@ -493,7 +496,11 @@ public class BottomSheetLayout extends FrameLayout {
      * @return The peeked state translation for the presented sheet view. Translation is counted from the bottom of the view.
      */
     public float getPeekSheetTranslation() {
-        return hasFullHeightSheet() ?  getHeight() / 3 : getSheetView().getHeight();
+        return peek == 0 ? (hasFullHeightSheet() ? getHeight() / 3 : getSheetView().getHeight()) : peek;
+    }
+
+    public void setPeekSheetTranslation(float peek) {
+        this.peek = peek;
     }
 
     /**


### PR DESCRIPTION
Hi, thanks for the library! Here I've added a programmatically custom peek.

Also I've fixed the dragging after recent merge from a pull request. Before wasn't possible anymore to drag up the sheet view if the click was on it due to return always false in method interceptTouchEvent. Now, the return value is in conjunction with condition where click happened.
Not perfectly visible in the example but if there are scrollable views below the sheet it works and you can always drag up the sheet if event is on it.