### PR TITLE
Post setting gridview columns if we are on Jelly Bean or below

### DIFF
--- a/bottomsheet-commons/src/main/java/com/flipboard/bottomsheet/commons/IntentPickerSheetView.java
+++ b/bottomsheet-commons/src/main/java/com/flipboard/bottomsheet/commons/IntentPickerSheetView.java
@@ -114,8 +114,19 @@ public class IntentPickerSheetView extends FrameLayout {
     @Override
     protected void onLayout(boolean changed, int left, int top, int right, int bottom) {
         super.onLayout(changed, left, top, right, bottom);
-        float density = getResources().getDisplayMetrics().density;
-        appGrid.setNumColumns((int) (getWidth() / (100 * density)));
+        final float density = getResources().getDisplayMetrics().density;
+        if (Build.VERSION.SDK_INT > Build.VERSION_CODES.JELLY_BEAN) {
+            appGrid.setNumColumns((int) (getWidth() / (100 * density)));
+        } else {
+            // On Jelly Bean and below setNumColumns does not redraw the view if we call it during
+            // a layout pass. We must post setting the number of columns to avoid this.
+            post(new Runnable() {
+                @Override
+                public void run() {
+                    appGrid.setNumColumns((int) (getWidth() / (100 * density)));
+                }
+            });
+        }
     }
 
     @Override

--- a/bottomsheet-commons/src/main/java/com/flipboard/bottomsheet/commons/MenuSheetView.java
+++ b/bottomsheet-commons/src/main/java/com/flipboard/bottomsheet/commons/MenuSheetView.java
@@ -127,8 +127,19 @@ public class MenuSheetView extends FrameLayout {
     protected void onLayout(boolean changed, int left, int top, int right, int bottom) {
         super.onLayout(changed, left, top, right, bottom);
         if (menuType == GRID) {
-            float density = getResources().getDisplayMetrics().density;
-            ((GridView) absListView).setNumColumns((int) (getWidth() / (100 * density)));
+            final float density = getResources().getDisplayMetrics().density;
+            if (Build.VERSION.SDK_INT > Build.VERSION_CODES.JELLY_BEAN) {
+                ((GridView) absListView).setNumColumns((int) (getWidth() / (100 * density)));
+            } else {
+                // On Jelly Bean and below setNumColumns does not redraw the view if we call it during
+                // a layout pass. We must post setting the number of columns to avoid this.
+                post(new Runnable() {
+                    @Override
+                    public void run() {
+                        ((GridView) absListView).setNumColumns((int) (getWidth() / (100 * density)));
+                    }
+                });
+            }
         }
     }
 


### PR DESCRIPTION
On Jelly Bean and below, setNumColumns does not redraw the view if we
call it during a layout pass. We must post setting the number of columns
to avoid this. Fixes #31.