### PR TITLE
Use pre-defined widths for tablets when sheet params are WRAP_CONTENT

### DIFF
--- a/bottomsheet/build.gradle
+++ b/bottomsheet/build.gradle
@@ -16,6 +16,8 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_7
         targetCompatibility JavaVersion.VERSION_1_7
     }
+
+    resourcePrefix 'bottomsheet_'
 }
 
 dependencies {

--- a/bottomsheet/src/main/java/com/flipboard/bottomsheet/BottomSheetLayout.java
+++ b/bottomsheet/src/main/java/com/flipboard/bottomsheet/BottomSheetLayout.java
@@ -7,11 +7,13 @@ import android.animation.TimeInterpolator;
 import android.annotation.TargetApi;
 import android.content.Context;
 import android.graphics.Color;
+import android.graphics.Point;
 import android.graphics.Rect;
 import android.os.Build;
 import android.support.annotation.NonNull;
 import android.util.AttributeSet;
 import android.util.Property;
+import android.view.Gravity;
 import android.view.KeyEvent;
 import android.view.MotionEvent;
 import android.view.VelocityTracker;
@@ -19,8 +21,11 @@ import android.view.View;
 import android.view.ViewConfiguration;
 import android.view.ViewGroup;
 import android.view.ViewTreeObserver;
+import android.view.WindowManager;
 import android.view.animation.DecelerateInterpolator;
 import android.widget.FrameLayout;
+
+import flipboard.bottomsheet.R;
 
 public class BottomSheetLayout extends FrameLayout {
 
@@ -92,6 +97,13 @@ public class BottomSheetLayout extends FrameLayout {
     private int currentSheetViewHeight;
     private boolean hasIntercepted;
 
+    /** Some values we need to manage width on tablets */
+    private int screenWidth = 0;
+    private final boolean isTablet = getResources().getBoolean(R.bool.bottomsheet_is_tablet);
+    private final int defaultSheetWidth = getResources().getDimensionPixelSize(R.dimen.bottomsheet_default_sheet_width);
+    private int sheetStartX = 0;
+    private int sheetEndX = 0;
+
     /** Snapshot of the touch's y position on a down event */
     private float downY;
 
@@ -134,6 +146,10 @@ public class BottomSheetLayout extends FrameLayout {
         dimView.setAlpha(0);
 
         setFocusableInTouchMode(true);
+
+        Point point = new Point();
+        ((WindowManager) getContext().getSystemService(Context.WINDOW_SERVICE)).getDefaultDisplay().getSize(point);
+        screenWidth = point.x;
     }
 
     /**
@@ -244,7 +260,7 @@ public class BottomSheetLayout extends FrameLayout {
         if (downAction) {
             hasIntercepted = false;
         }
-        if (interceptContentTouch || ev.getY() > getHeight() - sheetTranslation) {
+        if (interceptContentTouch || (ev.getY() > getHeight() - sheetTranslation && isXInSheet(ev.getX()))) {
             hasIntercepted = downAction && isSheetShowing();
         } else {
             hasIntercepted = false;
@@ -389,16 +405,20 @@ public class BottomSheetLayout extends FrameLayout {
             }
         } else {
             // If the user clicks outside of the bottom sheet area we should dismiss the bottom sheet.
-            boolean touchAboveBottomSheet = event.getY() < (getHeight() - sheetTranslation);
-            if (event.getAction() == MotionEvent.ACTION_UP && touchAboveBottomSheet && interceptContentTouch) {
+            boolean touchOutsideBottomSheet = event.getY() < getHeight() - sheetTranslation || !isXInSheet(event.getX());
+            if (event.getAction() == MotionEvent.ACTION_UP && touchOutsideBottomSheet && interceptContentTouch) {
                 dismissSheet();
                 return true;
             }
 
-            event.offsetLocation(0, sheetTranslation - getHeight());
+            event.offsetLocation(isTablet ? getX() - sheetStartX : 0, sheetTranslation - getHeight());
             getSheetView().dispatchTouchEvent(event);
         }
         return true;
+    }
+
+    private boolean isXInSheet(float x) {
+        return !isTablet || x > sheetStartX && x < sheetEndX;
     }
 
     private boolean isAnimating() {
@@ -564,12 +584,27 @@ public class BottomSheetLayout extends FrameLayout {
         if (state != State.HIDDEN) {
             throw new IllegalStateException("A sheet view is already presented, make sure to dismiss it before showing another.");
         }
+
         LayoutParams params = (LayoutParams) sheetView.getLayoutParams();
-        if (params != null) {
-            params.width = ViewGroup.LayoutParams.MATCH_PARENT;
-        } else {
-            params = generateDefaultLayoutParams();
+        if (params == null) {
+            params = new LayoutParams(isTablet ? LayoutParams.WRAP_CONTENT : LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT, Gravity.CENTER_HORIZONTAL);
         }
+
+        if (isTablet && params.width == FrameLayout.LayoutParams.WRAP_CONTENT) {
+
+            // Center by default if they didn't specify anything
+            if (params.gravity == -1) {
+                params.gravity = Gravity.CENTER_HORIZONTAL;
+            }
+
+            params.width = defaultSheetWidth;
+
+            // Update start and end coordinates for touch reference
+            int horizontalSpacing = screenWidth - defaultSheetWidth;
+            sheetStartX = horizontalSpacing / 2;
+            sheetEndX = screenWidth - sheetStartX;
+        }
+
         super.addView(sheetView, -1, params);
         initializeSheetValues();
         this.viewTransformer = viewTransformer;
@@ -649,6 +684,8 @@ public class BottomSheetLayout extends FrameLayout {
         });
         anim.start();
         currentAnimator = anim;
+        sheetStartX = 0;
+        sheetEndX = 0;
     }
 
     /**

--- a/bottomsheet/src/main/java/com/flipboard/bottomsheet/BottomSheetLayout.java
+++ b/bottomsheet/src/main/java/com/flipboard/bottomsheet/BottomSheetLayout.java
@@ -150,6 +150,7 @@ public class BottomSheetLayout extends FrameLayout {
         Point point = new Point();
         ((WindowManager) getContext().getSystemService(Context.WINDOW_SERVICE)).getDefaultDisplay().getSize(point);
         screenWidth = point.x;
+        sheetEndX = screenWidth;
     }
 
     /**
@@ -418,7 +419,7 @@ public class BottomSheetLayout extends FrameLayout {
     }
 
     private boolean isXInSheet(float x) {
-        return !isTablet || x > sheetStartX && x < sheetEndX;
+        return !isTablet || x >= sheetStartX && x <= sheetEndX;
     }
 
     private boolean isAnimating() {
@@ -685,7 +686,7 @@ public class BottomSheetLayout extends FrameLayout {
         anim.start();
         currentAnimator = anim;
         sheetStartX = 0;
-        sheetEndX = 0;
+        sheetEndX = screenWidth;
     }
 
     /**

--- a/bottomsheet/src/main/res/values-sw600dp/bool.xml
+++ b/bottomsheet/src/main/res/values-sw600dp/bool.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <bool name="bottomsheet_is_tablet">true</bool>
+</resources>

--- a/bottomsheet/src/main/res/values-sw600dp/dimens.xml
+++ b/bottomsheet/src/main/res/values-sw600dp/dimens.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="bottomsheet_default_sheet_width">446dp</dimen>
+</resources>

--- a/bottomsheet/src/main/res/values-sw720dp/bool.xml
+++ b/bottomsheet/src/main/res/values-sw720dp/bool.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <bool name="bottomsheet_is_tablet">true</bool>
+</resources>

--- a/bottomsheet/src/main/res/values-sw720dp/dimens.xml
+++ b/bottomsheet/src/main/res/values-sw720dp/dimens.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <dimen name="default_sheet_width">480dp</dimen>
+    <dimen name="bottomsheet_default_sheet_width">480dp</dimen>
 </resources>

--- a/bottomsheet/src/main/res/values-sw720dp/dimens.xml
+++ b/bottomsheet/src/main/res/values-sw720dp/dimens.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="default_sheet_width">480dp</dimen>
+</resources>

--- a/bottomsheet/src/main/res/values/bool.xml
+++ b/bottomsheet/src/main/res/values/bool.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <bool name="bottomsheet_is_tablet">false</bool>
+</resources>

--- a/bottomsheet/src/main/res/values/dimens.xml
+++ b/bottomsheet/src/main/res/values/dimens.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="bottomsheet_default_sheet_width">0dp</dimen>
+</resources>


### PR DESCRIPTION
This introduces some proper width handling on tablets. Forcing all sheets to be the same width as the parent can be a bad UI experience, especially for short lines of text.

This is based on what the system does for the width of the notification panel, with custom sizes for sw600dp and sw720dp screen densities.

Before

A | B | C
---|---|---
![volantismpz79mhsweers08032015000139](https://cloud.githubusercontent.com/assets/1361086/9032393/144929d6-3973-11e5-907a-6471b2884e30.png) | ![volantismpz79mhsweers08032015000132](https://cloud.githubusercontent.com/assets/1361086/9032401/215267c8-3973-11e5-854a-61896baaf3b9.png) | ![volantismpz79mhsweers08032015000120](https://cloud.githubusercontent.com/assets/1361086/9032446/96ef3768-3973-11e5-9073-a839c7f0ac6f.png)

After

A | B | C
---|---|---
![volantismpz79mhsweers08022015214612](https://cloud.githubusercontent.com/assets/1361086/9031010/09cdd190-3960-11e5-8ad0-edd3cd8989c4.png) | ![volantismpz79mhsweers08022015214626](https://cloud.githubusercontent.com/assets/1361086/9031012/09cf8238-3960-11e5-9e82-baace1505945.png) | ![volantismpz79mhsweers08022015214638](https://cloud.githubusercontent.com/assets/1361086/9031011/09cf7284-3960-11e5-8e46-b2f597e71d7d.png)
