### PR TITLE
Make bottomsheet work with YoutubePlayer from the Youtube SDK

### DIFF
--- a/bottomsheet/src/main/java/com/flipboard/bottomsheet/BottomSheetLayout.java
+++ b/bottomsheet/src/main/java/com/flipboard/bottomsheet/BottomSheetLayout.java
@@ -146,6 +146,7 @@ public class BottomSheetLayout extends FrameLayout {
         dimView = new View(getContext());
         dimView.setBackgroundColor(Color.BLACK);
         dimView.setAlpha(0);
+        dimView.setVisibility(INVISIBLE);
 
         peek = 0;//getHeight() return 0 at start!
 
@@ -240,7 +241,11 @@ public class BottomSheetLayout extends FrameLayout {
         this.contentClipRect.set(0, 0, getWidth(), bottomClip);
         getSheetView().setTranslationY(getHeight() - sheetTranslation);
         transformView(sheetTranslation);
-        dimView.setAlpha(shouldDimContentView ? getDimAlpha(sheetTranslation) : 0);
+        if (shouldDimContentView) {
+            float dimAlpha = getDimAlpha(sheetTranslation);
+            dimView.setAlpha(dimAlpha);
+            dimView.setVisibility(dimAlpha > 0 ? VISIBLE : INVISIBLE);
+        }
     }
 
     private void transformView(float sheetTranslation) {
@@ -479,6 +484,7 @@ public class BottomSheetLayout extends FrameLayout {
         this.contentClipRect.set(0, 0, getWidth(), getHeight());
         getSheetView().setTranslationY(getHeight());
         dimView.setAlpha(0);
+        dimView.setVisibility(INVISIBLE);
     }
 
     /**


### PR DESCRIPTION
The player pauses if something is covering it. In the bottomsheet case, the dimview was always covering it
The alpha was always 0 in the closed state, but the player doesn't care about that
Setting dimView to INVISIBLE makes the player work. It will still pause when a sheet is opened, but that seems like expected behavior, and it can be resume after closing the sheet