### PR TITLE
RecyclerView support in MenuSheetView

### DIFF
--- a/bottomsheet-commons/build.gradle
+++ b/bottomsheet-commons/build.gradle
@@ -21,7 +21,8 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile project(':bottomsheet')
-    compile 'com.android.support:support-v4:23.0.0'
+    compile 'com.android.support:support-v4:23.0.1'
+    compile 'com.android.support:recyclerview-v7:23.0.1'
 }
 
 publish {

--- a/bottomsheet-commons/src/main/java/com/flipboard/bottomsheet/commons/MenuSheetView.java
+++ b/bottomsheet-commons/src/main/java/com/flipboard/bottomsheet/commons/MenuSheetView.java
@@ -442,10 +442,10 @@ public class MenuSheetView extends FrameLayout {
             return getItem(position).hashCode();
         }
 
-        @Override public RecyclerView.ViewHolder onCreateViewHolder(ViewGroup viewGroup, int i) {
+        @Override public RecyclerView.ViewHolder onCreateViewHolder(ViewGroup viewGroup, int viewType) {
             View itemView = null;
 
-            switch (getItemViewType(i)){
+            switch (viewType){
 
                 case VIEW_TYPE_NORMAL:
                     itemView = inflater.inflate(menuType == RECYCLER_GRID ? R.layout.sheet_grid_item : R.layout.sheet_list_item, viewGroup, false);
@@ -517,12 +517,9 @@ public class MenuSheetView extends FrameLayout {
         }
 
         class SubheaderViewholder extends RecyclerView.ViewHolder{
-            final View itemView;
 
             public SubheaderViewholder(View itemView) {
                 super(itemView);
-                this.itemView = itemView;
-
             }
 
             public void bindText(SheetMenuItem item){
@@ -533,7 +530,6 @@ public class MenuSheetView extends FrameLayout {
         class SeperatorViewHolder extends RecyclerView.ViewHolder{
             public SeperatorViewHolder(View itemView) {
                 super(itemView);
-                itemView.setEnabled(false);
             }
         }
     }

--- a/bottomsheet-commons/src/main/java/com/flipboard/bottomsheet/commons/MenuSheetView.java
+++ b/bottomsheet-commons/src/main/java/com/flipboard/bottomsheet/commons/MenuSheetView.java
@@ -7,6 +7,7 @@ import android.support.annotation.MenuRes;
 import android.support.annotation.Nullable;
 import android.support.annotation.StringRes;
 import android.support.v4.view.ViewCompat;
+import android.support.v7.widget.RecyclerView;
 import android.text.TextUtils;
 import android.view.LayoutInflater;
 import android.view.Menu;
@@ -352,6 +353,112 @@ public class MenuSheetView extends FrameLayout {
             public void bindView(SheetMenuItem item) {
                 icon.setImageDrawable(item.getMenuItem().getIcon());
                 label.setText(item.getMenuItem().getTitle());
+            }
+        }
+    }
+
+    public class RecyclerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder>{
+
+        private static final int VIEW_TYPE_NORMAL = 0;
+        private static final int VIEW_TYPE_SUBHEADER = 1;
+        private static final int VIEW_TYPE_SEPARATOR = 2;
+
+        private final LayoutInflater inflater;
+
+        public RecyclerAdapter(){
+            this.inflater = LayoutInflater.from(getContext());
+        }
+
+        @Override public int getItemViewType(int position) {
+
+            SheetMenuItem item = getItem(position);
+            if (item.isSeparator()) {
+                return VIEW_TYPE_SEPARATOR;
+            } else if (item.getMenuItem().hasSubMenu()) {
+                return VIEW_TYPE_SUBHEADER;
+            } else {
+                return VIEW_TYPE_NORMAL;
+            }
+        }
+
+        public SheetMenuItem getItem(int position){
+            return items.get(position);
+        }
+
+        @Override public RecyclerView.ViewHolder onCreateViewHolder(ViewGroup viewGroup, int i) {
+            View itemView = null;
+
+            switch (getItemViewType(i)){
+
+                case VIEW_TYPE_NORMAL:
+                    itemView = inflater.inflate(menuType == GRID ? R.layout.sheet_grid_item : R.layout.sheet_list_item, viewGroup, false);
+                    return new NormalViewHolder(itemView);
+
+                case VIEW_TYPE_SUBHEADER:
+                    itemView = inflater.inflate(R.layout.sheet_list_item_subheader, viewGroup, false);
+                    return new SubheaderViewholder(itemView);
+
+                case VIEW_TYPE_SEPARATOR:
+                    itemView = inflater.inflate(R.layout.sheet_list_item_separator, viewGroup, false);
+                    return new SubheaderViewholder(itemView);
+
+            }
+            return null;
+        }
+
+        @Override public void onBindViewHolder(RecyclerView.ViewHolder viewHolder, int i) {
+            SheetMenuItem item = getItem(i);
+
+            switch (getItemViewType(i)){
+
+                case VIEW_TYPE_NORMAL:
+                    ((NormalViewHolder) viewHolder).bindView(item);
+                    break;
+
+                case VIEW_TYPE_SUBHEADER:
+                    ((SubheaderViewholder) viewHolder).bindText(item);
+                    break;
+            }
+
+        }
+
+        @Override public int getItemCount() {
+            return items.size();
+        }
+
+        class NormalViewHolder extends RecyclerView.ViewHolder{
+            final ImageView icon;
+            final TextView label;
+
+            NormalViewHolder(View root) {
+                super(root);
+                icon = (ImageView) root.findViewById(R.id.icon);
+                label = (TextView) root.findViewById(R.id.label);
+            }
+
+            public void bindView(SheetMenuItem item) {
+                icon.setImageDrawable(item.getMenuItem().getIcon());
+                label.setText(item.getMenuItem().getTitle());
+            }
+        }
+
+        class SubheaderViewholder extends RecyclerView.ViewHolder{
+            final View itemView;
+
+            public SubheaderViewholder(View itemView) {
+                super(itemView);
+                this.itemView = itemView;
+
+            }
+
+            public void bindText(SheetMenuItem item){
+                ((TextView)itemView).setText(item.getMenuItem().getTitle());
+            }
+        }
+
+        class SeperatorViewHolder extends RecyclerView.ViewHolder{
+            public SeperatorViewHolder(View itemView) {
+                super(itemView);
             }
         }
     }

--- a/bottomsheet-commons/src/main/java/com/flipboard/bottomsheet/commons/MenuSheetView.java
+++ b/bottomsheet-commons/src/main/java/com/flipboard/bottomsheet/commons/MenuSheetView.java
@@ -7,7 +7,6 @@ import android.support.annotation.MenuRes;
 import android.support.annotation.Nullable;
 import android.support.annotation.StringRes;
 import android.support.v4.view.ViewCompat;
-import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.text.TextUtils;
 import android.view.LayoutInflater;
@@ -27,7 +26,6 @@ import android.widget.PopupMenu;
 import android.widget.TextView;
 
 import java.util.ArrayList;
-import java.util.List;
 
 import flipboard.bottomsheet.commons.R;
 

--- a/bottomsheet-commons/src/main/java/com/flipboard/bottomsheet/commons/WrapLinearLayoutManager.java
+++ b/bottomsheet-commons/src/main/java/com/flipboard/bottomsheet/commons/WrapLinearLayoutManager.java
@@ -10,7 +10,7 @@ import android.view.ViewGroup;
 /**
  * Created by AKiniyalocts on 4/21/15.
  *
- * There is a problem when having a nested recycler view with a dynamic height. i.e. "wrap_content"
+ * There is a problem when having a recycler view with a dynamic height. i.e. "wrap_content"
  * This (99%) fixes that problem.
  */
 public class WrapLinearLayoutManager extends LinearLayoutManager {

--- a/bottomsheet-commons/src/main/java/com/flipboard/bottomsheet/commons/WrapLinearLayoutManager.java
+++ b/bottomsheet-commons/src/main/java/com/flipboard/bottomsheet/commons/WrapLinearLayoutManager.java
@@ -1,0 +1,88 @@
+package com.flipboard.bottomsheet.commons;
+
+
+import android.content.Context;
+import android.support.v7.widget.LinearLayoutManager;
+import android.support.v7.widget.RecyclerView;
+import android.view.View;
+import android.view.ViewGroup;
+
+/**
+ * Created by AKiniyalocts on 4/21/15.
+ *
+ * There is a problem when having a nested recycler view with a dynamic height. i.e. "wrap_content"
+ * This (99%) fixes that problem.
+ */
+public class WrapLinearLayoutManager extends LinearLayoutManager {
+
+    public WrapLinearLayoutManager(Context context){
+        super(context, LinearLayoutManager.VERTICAL, false);
+    }
+
+    public WrapLinearLayoutManager(Context context, int orientation, boolean reverseLayout){
+        super(context, orientation, reverseLayout);
+    }
+
+    private int[] mMeasuredDimension = new int[2];
+
+    @Override
+    public void onMeasure(RecyclerView.Recycler recycler, RecyclerView.State state,
+                          int widthSpec, int heightSpec) {
+        final int widthMode = View.MeasureSpec.getMode(widthSpec);
+        final int heightMode = View.MeasureSpec.getMode(heightSpec);
+        final int widthSize = View.MeasureSpec.getSize(widthSpec);
+        final int heightSize = View.MeasureSpec.getSize(heightSpec);
+        int width = 0;
+        int height = 0;
+        for (int i = 0; i < getItemCount(); i++) {
+            measureScrapChild(recycler, i,
+                    View.MeasureSpec.makeMeasureSpec(i, View.MeasureSpec.UNSPECIFIED),
+                    View.MeasureSpec.makeMeasureSpec(i, View.MeasureSpec.UNSPECIFIED),
+                    mMeasuredDimension);
+
+            if (getOrientation() == HORIZONTAL) {
+                width = width + mMeasuredDimension[0];
+                if (i == 0) {
+                    height = mMeasuredDimension[1];
+                }
+            } else {
+                height = height + mMeasuredDimension[1];
+                if (i == 0) {
+                    width = mMeasuredDimension[0];
+                }
+            }
+        }
+        switch (widthMode) {
+            case View.MeasureSpec.EXACTLY:
+                width = widthSize;
+            case View.MeasureSpec.AT_MOST:
+            case View.MeasureSpec.UNSPECIFIED:
+        }
+
+        switch (heightMode) {
+            case View.MeasureSpec.EXACTLY:
+                height = heightSize;
+            case View.MeasureSpec.AT_MOST:
+            case View.MeasureSpec.UNSPECIFIED:
+        }
+
+        setMeasuredDimension(width, height);
+    }
+
+    private void measureScrapChild(RecyclerView.Recycler recycler, int position, int widthSpec,
+                                   int heightSpec, int[] measuredDimension) {
+        View view = recycler.getViewForPosition(position);
+        if (view != null) {
+            RecyclerView.LayoutParams p = (RecyclerView.LayoutParams) view.getLayoutParams();
+            int childWidthSpec = ViewGroup.getChildMeasureSpec(widthSpec,
+                    getPaddingLeft() + getPaddingRight(), p.width);
+            int childHeightSpec = ViewGroup.getChildMeasureSpec(heightSpec,
+                    getPaddingTop() + getPaddingBottom(), p.height);
+            view.measure(childWidthSpec, childHeightSpec);
+            measuredDimension[0] = view.getMeasuredWidth() + p.leftMargin + p.rightMargin;
+            measuredDimension[1] = view.getMeasuredHeight() + p.bottomMargin + p.topMargin;
+            recycler.recycleView(view);
+        }
+    }
+}
+

--- a/bottomsheet-commons/src/main/res/layout/recycler_sheet_view.xml
+++ b/bottomsheet-commons/src/main/res/layout/recycler_sheet_view.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@android:color/white">
+
+    <TextView
+        android:id="@+id/title"
+        android:layout_width="match_parent"
+        android:layout_height="56dp"
+        android:layout_marginStart="16dp"
+        android:layout_marginLeft="16dp"
+        android:layout_marginRight="16dp"
+        android:layout_marginEnd="16dp"
+        android:gravity="center_vertical"
+        android:textColor="@color/text_gray"
+        android:textSize="16sp"
+        tools:text="Title"
+        />
+
+    <android.support.v7.widget.RecyclerView
+        android:id="@+id/recycler"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:paddingBottom="8dp"
+        android:clipToPadding="false"
+        />
+
+</LinearLayout>

--- a/bottomsheet-commons/src/main/res/layout/sheet_grid_item.xml
+++ b/bottomsheet-commons/src/main/res/layout/sheet_grid_item.xml
@@ -3,6 +3,7 @@
     android:orientation="vertical"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:background="?android:attr/selectableItemBackground"
     android:gravity="center"
     android:paddingTop="8dp"
     android:paddingBottom="8dp"

--- a/bottomsheet-commons/src/main/res/layout/sheet_list_item.xml
+++ b/bottomsheet-commons/src/main/res/layout/sheet_list_item.xml
@@ -3,6 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:background="?android:attr/selectableItemBackground"
     android:minHeight="48dp"
     android:gravity="center"
     >

--- a/bottomsheet-sample/src/main/java/com/flipboard/bottomsheet/sample/MenuActivity.java
+++ b/bottomsheet-sample/src/main/java/com/flipboard/bottomsheet/sample/MenuActivity.java
@@ -13,6 +13,7 @@ import android.widget.Toast;
 import com.flipboard.bottomsheet.BottomSheetLayout;
 import com.flipboard.bottomsheet.R;
 import com.flipboard.bottomsheet.commons.MenuSheetView;
+import com.flipboard.bottomsheet.commons.WrapLinearLayoutManager;
 
 /**
  * Activity demonstrating the use of {@link MenuSheetView}
@@ -48,7 +49,7 @@ public class MenuActivity extends AppCompatActivity {
         findViewById(R.id.recycler_button_list).setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                showMenuSheet(new LinearLayoutManager(MenuActivity.this), MenuSheetView.MenuType.RECYCLER_LIST);
+                showMenuSheet(new WrapLinearLayoutManager(MenuActivity.this), MenuSheetView.MenuType.RECYCLER_LIST);
             }
         });
     }
@@ -69,10 +70,6 @@ public class MenuActivity extends AppCompatActivity {
             bottomSheetLayout.showWithSheetView(menuSheetView);
     }
 
-    /**
-     *
-     * @param layoutManager @link  android.support.v7.widget.RecyclerView.LayoutManager
-     */
     private void showMenuSheet(RecyclerView.LayoutManager layoutManager, MenuSheetView.MenuType menuType){
         MenuSheetView menuSheetView = new MenuSheetView(MenuActivity.this, layoutManager, menuType, "Create...", new MenuSheetView.OnMenuItemClickListener() {
             @Override

--- a/bottomsheet-sample/src/main/java/com/flipboard/bottomsheet/sample/MenuActivity.java
+++ b/bottomsheet-sample/src/main/java/com/flipboard/bottomsheet/sample/MenuActivity.java
@@ -42,22 +42,18 @@ public class MenuActivity extends AppCompatActivity {
         findViewById(R.id.recycler_button_grid).setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                showMenuSheet(new GridLayoutManager(MenuActivity.this, 3));
+                showMenuSheet(new GridLayoutManager(MenuActivity.this, 3), MenuSheetView.MenuType.RECYCLER_GRID);
             }
         });
         findViewById(R.id.recycler_button_list).setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                showMenuSheet(new LinearLayoutManager(MenuActivity.this));
+                showMenuSheet(new LinearLayoutManager(MenuActivity.this), MenuSheetView.MenuType.RECYCLER_LIST);
             }
         });
     }
 
     private void showMenuSheet(MenuSheetView.MenuType menuType) {
-        if(menuType == MenuSheetView.MenuType.RECYCLER){
-
-        }
-        else {
             MenuSheetView menuSheetView =
                     new MenuSheetView(MenuActivity.this, menuType, "Create...", new MenuSheetView.OnMenuItemClickListener() {
                         @Override
@@ -71,11 +67,14 @@ public class MenuActivity extends AppCompatActivity {
                     });
             menuSheetView.inflateMenu(R.menu.create);
             bottomSheetLayout.showWithSheetView(menuSheetView);
-        }
     }
 
-    private void showMenuSheet(RecyclerView.LayoutManager layoutManager){
-        MenuSheetView menuSheetView = new MenuSheetView(MenuActivity.this, layoutManager, "Create...", new MenuSheetView.OnMenuItemClickListener() {
+    /**
+     *
+     * @param layoutManager @link  android.support.v7.widget.RecyclerView.LayoutManager
+     */
+    private void showMenuSheet(RecyclerView.LayoutManager layoutManager, MenuSheetView.MenuType menuType){
+        MenuSheetView menuSheetView = new MenuSheetView(MenuActivity.this, layoutManager, menuType, "Create...", new MenuSheetView.OnMenuItemClickListener() {
             @Override
             public boolean onMenuItemClick(MenuItem item) {
                 Toast.makeText(MenuActivity.this, item.getTitle(), Toast.LENGTH_SHORT).show();

--- a/bottomsheet-sample/src/main/java/com/flipboard/bottomsheet/sample/MenuActivity.java
+++ b/bottomsheet-sample/src/main/java/com/flipboard/bottomsheet/sample/MenuActivity.java
@@ -2,6 +2,10 @@ package com.flipboard.bottomsheet.sample;
 
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
+import android.support.v7.widget.GridLayoutManager;
+import android.support.v7.widget.LinearLayoutManager;
+import android.support.v7.widget.RecyclerView;
+import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
 import android.widget.Toast;
@@ -35,20 +39,52 @@ public class MenuActivity extends AppCompatActivity {
                 showMenuSheet(MenuSheetView.MenuType.GRID);
             }
         });
+        findViewById(R.id.recycler_button_grid).setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                showMenuSheet(new GridLayoutManager(MenuActivity.this, 3));
+            }
+        });
+        findViewById(R.id.recycler_button_list).setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                showMenuSheet(new LinearLayoutManager(MenuActivity.this));
+            }
+        });
     }
 
     private void showMenuSheet(MenuSheetView.MenuType menuType) {
-        MenuSheetView menuSheetView =
-                new MenuSheetView(MenuActivity.this, menuType, "Create...", new MenuSheetView.OnMenuItemClickListener() {
-                    @Override
-                    public boolean onMenuItemClick(MenuItem item) {
-                        Toast.makeText(MenuActivity.this, item.getTitle(), Toast.LENGTH_SHORT).show();
-                        if (bottomSheetLayout.isSheetShowing()) {
-                            bottomSheetLayout.dismissSheet();
+        if(menuType == MenuSheetView.MenuType.RECYCLER){
+
+        }
+        else {
+            MenuSheetView menuSheetView =
+                    new MenuSheetView(MenuActivity.this, menuType, "Create...", new MenuSheetView.OnMenuItemClickListener() {
+                        @Override
+                        public boolean onMenuItemClick(MenuItem item) {
+                            Toast.makeText(MenuActivity.this, item.getTitle(), Toast.LENGTH_SHORT).show();
+                            if (bottomSheetLayout.isSheetShowing()) {
+                                bottomSheetLayout.dismissSheet();
+                            }
+                            return true;
                         }
-                        return true;
-                    }
-                });
+                    });
+            menuSheetView.inflateMenu(R.menu.create);
+            bottomSheetLayout.showWithSheetView(menuSheetView);
+        }
+    }
+
+    private void showMenuSheet(RecyclerView.LayoutManager layoutManager){
+        MenuSheetView menuSheetView = new MenuSheetView(MenuActivity.this, layoutManager, "Create...", new MenuSheetView.OnMenuItemClickListener() {
+            @Override
+            public boolean onMenuItemClick(MenuItem item) {
+                Toast.makeText(MenuActivity.this, item.getTitle(), Toast.LENGTH_SHORT).show();
+                if (bottomSheetLayout.isSheetShowing()) {
+                    bottomSheetLayout.dismissSheet();
+                }
+                return true;
+            }
+        });
         menuSheetView.inflateMenu(R.menu.create);
         bottomSheetLayout.showWithSheetView(menuSheetView);
     }

--- a/bottomsheet-sample/src/main/java/com/flipboard/bottomsheet/sample/MenuActivity.java
+++ b/bottomsheet-sample/src/main/java/com/flipboard/bottomsheet/sample/MenuActivity.java
@@ -43,35 +43,18 @@ public class MenuActivity extends AppCompatActivity {
         findViewById(R.id.recycler_button_grid).setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                showMenuSheet(new GridLayoutManager(MenuActivity.this, 3), MenuSheetView.MenuType.RECYCLER_GRID);
+                showMenuSheet(MenuSheetView.MenuType.RECYCLER_GRID, new GridLayoutManager(MenuActivity.this, 3));
             }
         });
         findViewById(R.id.recycler_button_list).setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                showMenuSheet(new WrapLinearLayoutManager(MenuActivity.this), MenuSheetView.MenuType.RECYCLER_LIST);
+                showMenuSheet(MenuSheetView.MenuType.RECYCLER_LIST, new WrapLinearLayoutManager(MenuActivity.this));
             }
         });
     }
 
-<<<<<<< HEAD
-    private void showMenuSheet(MenuSheetView.MenuType menuType) {
-            MenuSheetView menuSheetView =
-                    new MenuSheetView(MenuActivity.this, menuType, "Create...", new MenuSheetView.OnMenuItemClickListener() {
-                        @Override
-                        public boolean onMenuItemClick(MenuItem item) {
-                            Toast.makeText(MenuActivity.this, item.getTitle(), Toast.LENGTH_SHORT).show();
-                            if (bottomSheetLayout.isSheetShowing()) {
-                                bottomSheetLayout.dismissSheet();
-                            }
-                            return true;
-                        }
-                    });
-            menuSheetView.inflateMenu(R.menu.create);
-            bottomSheetLayout.showWithSheetView(menuSheetView);
-    }
-
-    private void showMenuSheet(RecyclerView.LayoutManager layoutManager, MenuSheetView.MenuType menuType){
+    private void showMenuSheet( final MenuSheetView.MenuType menuType, RecyclerView.LayoutManager layoutManager) {
         MenuSheetView menuSheetView = new MenuSheetView(MenuActivity.this, layoutManager, menuType, "Create...", new MenuSheetView.OnMenuItemClickListener() {
             @Override
             public boolean onMenuItemClick(MenuItem item) {
@@ -79,10 +62,17 @@ public class MenuActivity extends AppCompatActivity {
                 if (bottomSheetLayout.isSheetShowing()) {
                     bottomSheetLayout.dismissSheet();
                 }
+                if (item.getItemId() == R.id.reopen) {
+                    showMenuSheet(menuType == MenuSheetView.MenuType.RECYCLER_LIST ? MenuSheetView.MenuType.RECYCLER_GRID : MenuSheetView.MenuType.RECYCLER_LIST,  getOtherLayoutManager(menuType));
+                }
                 return true;
             }
         });
-=======
+
+        menuSheetView.inflateMenu(R.menu.create);
+        bottomSheetLayout.showWithSheetView(menuSheetView);
+    }
+
     private void showMenuSheet(final MenuSheetView.MenuType menuType) {
         MenuSheetView menuSheetView =
                 new MenuSheetView(MenuActivity.this, menuType, "Create...", new MenuSheetView.OnMenuItemClickListener() {
@@ -98,8 +88,12 @@ public class MenuActivity extends AppCompatActivity {
                         return true;
                     }
                 });
->>>>>>> trunk/master
+
         menuSheetView.inflateMenu(R.menu.create);
         bottomSheetLayout.showWithSheetView(menuSheetView);
+    }
+
+    private RecyclerView.LayoutManager getOtherLayoutManager(MenuSheetView.MenuType menuType){
+        return menuType == MenuSheetView.MenuType.RECYCLER_LIST ? new GridLayoutManager(MenuActivity.this, 3) : new WrapLinearLayoutManager(MenuActivity.this);
     }
 }

--- a/bottomsheet-sample/src/main/res/layout/activity_menu.xml
+++ b/bottomsheet-sample/src/main/res/layout/activity_menu.xml
@@ -27,6 +27,18 @@
             android:text="@string/grid_button"
             />
 
+        <Button
+            android:id="@+id/recycler_button_grid"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/recycler_grid"/>
+
+        <Button
+            android:id="@+id/recycler_button_list"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/recycler_linear"/>
+
     </LinearLayout>
 
 </com.flipboard.bottomsheet.BottomSheetLayout>

--- a/bottomsheet-sample/src/main/res/values/strings.xml
+++ b/bottomsheet-sample/src/main/res/values/strings.xml
@@ -13,4 +13,7 @@
     <string name="share_some_text">Share some text!</string>
     <string name="image_picker">Image picker</string>
     <string name="show">Show</string>
+    <string name="recycler">Recycler</string>
+    <string name="recycler_grid">Recycler Grid</string>
+    <string name="recycler_linear">Recycler Linear</string>
 </resources>

--- a/bottomsheet-sample/src/main/res/values/strings.xml
+++ b/bottomsheet-sample/src/main/res/values/strings.xml
@@ -13,11 +13,8 @@
     <string name="share_some_text">Share some text!</string>
     <string name="image_picker">Image picker</string>
     <string name="show">Show</string>
-<<<<<<< HEAD
     <string name="recycler">Recycler</string>
     <string name="recycler_grid">Recycler Grid</string>
     <string name="recycler_linear">Recycler Linear</string>
-=======
     <string name="reopen">Reopen as other type</string>
->>>>>>> trunk/master
 </resources>


### PR DESCRIPTION
This adds support for RecyclerView in the bottom sheet for our MenuSheetView. I've included a `WrapLinearLayoutManager` to fix the wrap_content issue for a `LinearLayoutManager`. GridLayoutManager currently <strong>does not</strong> wrap content (fills the entire screen).

I've added an additional constructor for our `MenuSheetView` constructor, allowing you to pass in a `LayoutManager` for your recycler. I've also added two new `MenuType's`: `RECYCLER_LIST` and `RECYCLER_GRID`, which are also required in the `MenuSheetView` constructor when using a recycler.