### PR TITLE
Check permission for device with API 23 or higher

### DIFF
--- a/bottomsheet-commons/src/main/java/com/flipboard/bottomsheet/commons/ImagePickerSheetView.java
+++ b/bottomsheet-commons/src/main/java/com/flipboard/bottomsheet/commons/ImagePickerSheetView.java
@@ -381,8 +381,8 @@ public class ImagePickerSheetView extends FrameLayout {
         Drawable pickerDrawable = null;
 
         public Builder(@NonNull Context context) {
-            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M
-                    || ContextCompat.checkSelfPermission(context, Manifest.permission.READ_EXTERNAL_STORAGE) != PackageManager.PERMISSION_GRANTED) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M
+                    && ContextCompat.checkSelfPermission(context, Manifest.permission.READ_EXTERNAL_STORAGE) != PackageManager.PERMISSION_GRANTED) {
                 throw new RuntimeException("Missing required READ_EXTERNAL_STORAGE permission. Did you remember to request it first?");
             }
             this.context = context;

--- a/bottomsheet-commons/src/main/java/com/flipboard/bottomsheet/commons/ImagePickerSheetView.java
+++ b/bottomsheet-commons/src/main/java/com/flipboard/bottomsheet/commons/ImagePickerSheetView.java
@@ -381,7 +381,8 @@ public class ImagePickerSheetView extends FrameLayout {
         Drawable pickerDrawable = null;
 
         public Builder(@NonNull Context context) {
-            if (ContextCompat.checkSelfPermission(context, Manifest.permission.READ_EXTERNAL_STORAGE) != PackageManager.PERMISSION_GRANTED) {
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M
+                    || ContextCompat.checkSelfPermission(context, Manifest.permission.READ_EXTERNAL_STORAGE) != PackageManager.PERMISSION_GRANTED) {
                 throw new RuntimeException("Missing required READ_EXTERNAL_STORAGE permission. Did you remember to request it first?");
             }
             this.context = context;

--- a/bottomsheet-sample/src/main/java/com/flipboard/bottomsheet/sample/ImagePickerActivity.java
+++ b/bottomsheet-sample/src/main/java/com/flipboard/bottomsheet/sample/ImagePickerActivity.java
@@ -61,10 +61,11 @@ public final class ImagePickerActivity extends AppCompatActivity {
     }
 
     private boolean checkNeedsPermission() {
-        return Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN && ActivityCompat.checkSelfPermission(ImagePickerActivity.this, Manifest.permission.WRITE_EXTERNAL_STORAGE) != PackageManager.PERMISSION_GRANTED;
+        return Build.VERSION.SDK_INT >= Build.VERSION_CODES.M
+                && ActivityCompat.checkSelfPermission(ImagePickerActivity.this, Manifest.permission.WRITE_EXTERNAL_STORAGE) != PackageManager.PERMISSION_GRANTED;
     }
 
-    @TargetApi(Build.VERSION_CODES.JELLY_BEAN)
+    @TargetApi(Build.VERSION_CODES.M)
     private void requestStoragePermission() {
         if (ActivityCompat.shouldShowRequestPermissionRationale(this, Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
             ActivityCompat.requestPermissions(this, new String[]{Manifest.permission.WRITE_EXTERNAL_STORAGE}, REQUEST_STORAGE);


### PR DESCRIPTION
There is some bugs with rooted device with API under 23. So it will be nice if we add some defensive code to check permission only for device with API 23 or higher. And all the run time permission is for API 23 or higher anyway.

![untitled](https://cloud.githubusercontent.com/assets/3123741/12438530/08581d5c-bf6b-11e5-8974-cc1bdf7e79a2.png)