### PR TITLE
Check READ_EXTERNAL_STORAGE permission if API is higher than 16

### DIFF
--- a/bottomsheet-commons/src/main/java/com/flipboard/bottomsheet/commons/ImagePickerSheetView.java
+++ b/bottomsheet-commons/src/main/java/com/flipboard/bottomsheet/commons/ImagePickerSheetView.java
@@ -381,7 +381,8 @@ public class ImagePickerSheetView extends FrameLayout {
         Drawable pickerDrawable = null;
 
         public Builder(@NonNull Context context) {
-            if (ContextCompat.checkSelfPermission(context, Manifest.permission.READ_EXTERNAL_STORAGE) != PackageManager.PERMISSION_GRANTED) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN
+                    && ContextCompat.checkSelfPermission(context, Manifest.permission.READ_EXTERNAL_STORAGE) != PackageManager.PERMISSION_GRANTED) {
                 throw new RuntimeException("Missing required READ_EXTERNAL_STORAGE permission. Did you remember to request it first?");
             }
             this.context = context;


### PR DESCRIPTION
I finally figure out what was the problem. Because READ_EXTERNAL_STORAGE permission introduced API 16. Device with API under 16 which is 14, 15 in this case will always return `PERMISSION_DENIED` if you call `ContextCompat.checkSelfPermission(context, Manifest.permission.READ_EXTERNAL_STORAGE)` method. I think there should be one more return value such as `PERMISSION_DONT_EXIST` or something. Anyway this is not a bug.

There is nice [article](https://commonsware.com/blog/2015/11/09/you-cannot-hold-nonexistent-permissions.html) about this issues.

[Dexter](https://github.com/Karumi/Dexter/pull/22) which is promising permission library is taking care about this problem, too.

![untitled](https://cloud.githubusercontent.com/assets/3123741/12449723/a01a0310-bfc2-11e5-8197-2c012478c148.png)
If you see the crash report from my app. It crashes with device 4.0.4 and 4.0.3 which both are API 15.

**If you think this request is worth to merge, please release new version right after merge!**