### PR TITLE
Elastic force to prevent accidental dismiss of bottom sheet & Allow bottomsheet to open as expanded when height smaller than parent's.

### DIFF
--- a/bottomsheet/src/main/java/com/flipboard/bottomsheet/BottomSheetLayout.java
+++ b/bottomsheet/src/main/java/com/flipboard/bottomsheet/BottomSheetLayout.java
@@ -528,6 +528,10 @@ public class BottomSheetLayout extends FrameLayout {
      * Set the presented sheet to be in a peeked state.
      */
     public void peekSheet() {
+        if (getSheetView().getMeasuredHeight() < BottomSheetLayout.this.getMeasuredHeight()) {
+            expandSheet();
+            return;
+        }
         cancelCurrentAnimation();
         setSheetLayerTypeIfEnabled(LAYER_TYPE_HARDWARE);
         ObjectAnimator anim = ObjectAnimator.ofFloat(this, SHEET_TRANSLATION, getPeekSheetTranslation());
@@ -685,11 +689,7 @@ public class BottomSheetLayout extends FrameLayout {
                         // Make sure sheet view is still here when first draw happens.
                         // In the case of a large lag it could be that the view is dismissed before it is drawn resulting in sheet view being null here.
                         if (getSheetView() != null) {
-                            if (sheetView.getMeasuredHeight() >= BottomSheetLayout.this.getMeasuredHeight()) {
-                                peekSheet();
-                            } else {
-                                expandSheet();
-                            }
+                            peekSheet();
                         }
                     }
                 });

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.0.0-alpha3'
+        classpath 'com.android.tools.build:gradle:1.5.0'
         classpath 'com.novoda:bintray-release:0.3.4'
     }
 }


### PR DESCRIPTION
Elastic force to prevent accidental dismiss of bottom sheet.
If we move just a pixel, the bottom sheet is dismissed. with this feature, its behaviour is more like the native android bottomsheet's.

Allow bottomsheet to open as expanded when height smaller than parent's.
When you have a bottomsheet which height is smaller than the BottomSheetLayout's height, the bottomsheet starts (like it should when you call show). If the bottomsheet view is a scrollview, the first time you try to scroll, the bottomsheet doesn't allow because try to make it expanded, and only after that you can scroll. 
With this fix, if, for instance you put the bottomsheet view with 300dp height, and it is a listview, it just starts with Expanded state, and so you can always scroll inside that.