### PR TITLE
fixes issue #132 by taking x&y scrollposition into account

### DIFF
--- a/bottomsheet/src/main/java/com/flipboard/bottomsheet/BottomSheetLayout.java
+++ b/bottomsheet/src/main/java/com/flipboard/bottomsheet/BottomSheetLayout.java
@@ -450,13 +450,11 @@ public class BottomSheetLayout extends FrameLayout {
             ViewGroup vg = (ViewGroup) view;
             for (int i = 0; i < vg.getChildCount(); i++) {
                 View child = vg.getChildAt(i);
-
                 int childLeft = child.getLeft() - view.getScrollX();
                 int childTop = child.getTop() - view.getScrollY();
                 int childRight = child.getRight() - view.getScrollX();
                 int childBottom = child.getBottom() - view.getScrollY();
-
-                boolean intersects = childLeft < x && x < childRight && childTop < y && y < childBottom;
+                boolean intersects = x > childLeft && x < childRight && y > childTop && y < childBottom;
                 if (intersects && canScrollUp(child, x - childLeft, y - childTop)) {
                     return true;
                 }

--- a/bottomsheet/src/main/java/com/flipboard/bottomsheet/BottomSheetLayout.java
+++ b/bottomsheet/src/main/java/com/flipboard/bottomsheet/BottomSheetLayout.java
@@ -450,11 +450,13 @@ public class BottomSheetLayout extends FrameLayout {
             ViewGroup vg = (ViewGroup) view;
             for (int i = 0; i < vg.getChildCount(); i++) {
                 View child = vg.getChildAt(i);
-                int childLeft = child.getLeft();
-                int childTop = child.getTop();
-                int childRight = child.getRight();
-                int childBottom = child.getBottom();
-                boolean intersects = x > childLeft && x < childRight && y > childTop && y < childBottom;
+
+                int childLeft = child.getLeft() - view.getScrollX();
+                int childTop = child.getTop() - view.getScrollY();
+                int childRight = child.getRight() - view.getScrollX();
+                int childBottom = child.getBottom() - view.getScrollY();
+
+                boolean intersects = childLeft < x && x < childRight && childTop < y && y < childBottom;
                 if (intersects && canScrollUp(child, x - childLeft, y - childTop)) {
                     return true;
                 }


### PR DESCRIPTION
Fixes the scrolling bug in #132.

The problem was that scrolling-positons were not taken into account when `canScrollUp` tries to find the touched element. 

Therefore I am 'descrolling' the intersection-hitbox.

This picture tries to illustrate it:

![img_2563](https://cloud.githubusercontent.com/assets/3726563/14612587/376a0ba0-0598-11e6-9fd6-aa9a295be273.JPG)

(of course -scrollY on y-axis not -scrollX)

I think the failed travis build is due to a too old version.
> Plugin is too old, please update to a more recent version, or set ANDROID_DAILY_OVERRIDE environment variable to "c6930c23d36ab6b6b38444329718db02cc97d20d"