### PR TITLE
bugfix Flipboard/bottomsheet#134

### DIFF
--- a/bottomsheet/src/main/java/com/flipboard/bottomsheet/BottomSheetLayout.java
+++ b/bottomsheet/src/main/java/com/flipboard/bottomsheet/BottomSheetLayout.java
@@ -716,7 +716,6 @@ public class BottomSheetLayout extends FrameLayout {
                     // Remove sheet specific properties
                     viewTransformer = null;
                     onSheetDismissedListeners.clear();
-                    onSheetStateChangeListeners.clear();
                     if (runAfterDismiss != null) {
                         runAfterDismiss.run();
                         runAfterDismiss = null;


### PR DESCRIPTION
This is to address Flipboard/bottomsheet#134 that makes it impossible to attach state handlers to the later view when switching bottomsheet views (calling `showWithSheetView` when there is already a view in peek or expanded states)