### PR TITLE
Fix incorrect dimming and sheet position

### DIFF
--- a/bottomsheet/src/main/java/com/flipboard/bottomsheet/BottomSheetLayout.java
+++ b/bottomsheet/src/main/java/com/flipboard/bottomsheet/BottomSheetLayout.java
@@ -239,8 +239,8 @@ public class BottomSheetLayout extends FrameLayout {
         return super.onKeyPreIme(keyCode, event);
     }
 
-    private void setSheetTranslation(float sheetTranslation) {
-        this.sheetTranslation = sheetTranslation;
+    private void setSheetTranslation(float newTranslation) {
+        this.sheetTranslation = Math.min(newTranslation, getMaxSheetTranslation());
         int bottomClip = (int) (getHeight() - Math.ceil(sheetTranslation));
         this.contentClipRect.set(0, 0, getWidth(), bottomClip);
         getSheetView().setTranslationY(getHeight() - sheetTranslation);


### PR DESCRIPTION
If translation > maxSheetTranslation the sheet won't be attached to the bottom, and the dimAlpha can go beyond the max dimming value
Resolves https://github.com/Flipboard/bottomsheet/issues/91