### PR TITLE
Fix Extra Large Label UI on Grid Item on bottomsheet

### DIFF
--- a/bottomsheet-commons/src/main/res/layout/sheet_grid_item.xml
+++ b/bottomsheet-commons/src/main/res/layout/sheet_grid_item.xml
@@ -18,7 +18,9 @@
     <TextView
         android:id="@+id/label"
         android:layout_width="wrap_content"
-        android:layout_height="16dp"
+        android:layout_height="wrap_content"
+        android:paddingRight="@dimen/bottomsheet_grid_text_spacing"
+        android:paddingLeft="@dimen/bottomsheet_grid_text_spacing"
         android:gravity="center_horizontal"
         android:maxLines="1"
         android:textColor="@color/text_gray"

--- a/bottomsheet-commons/src/main/res/values/dimen.xml
+++ b/bottomsheet-commons/src/main/res/values/dimen.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <dimen name="bottomsheet_image_tile_spacing">4dp</dimen>
+    <dimen name="bottomsheet_grid_text_spacing">2dp</dimen>
 </resources>


### PR DESCRIPTION
Grid Item list text gets cut out when text size is extra large
![device-2016-07-20-133833](https://cloud.githubusercontent.com/assets/20525838/17002255/5541d5e2-4e7f-11e6-9771-4da52d25c30a.png)
