### PR TITLE
Fix initial bottom sheet height

### DIFF
--- a/bottomsheet/src/main/java/com/flipboard/bottomsheet/BottomSheetLayout.java
+++ b/bottomsheet/src/main/java/com/flipboard/bottomsheet/BottomSheetLayout.java
@@ -12,7 +12,6 @@ import android.graphics.Rect;
 import android.os.Build;
 import android.support.annotation.NonNull;
 import android.util.AttributeSet;
-import android.util.DisplayMetrics;
 import android.util.Property;
 import android.view.Gravity;
 import android.view.KeyEvent;

--- a/bottomsheet/src/main/java/com/flipboard/bottomsheet/BottomSheetLayout.java
+++ b/bottomsheet/src/main/java/com/flipboard/bottomsheet/BottomSheetLayout.java
@@ -101,6 +101,7 @@ public class BottomSheetLayout extends FrameLayout {
     private boolean interceptContentTouch = true;
     private int currentSheetViewHeight;
     private boolean hasIntercepted;
+    private float peekKeyline;
     private float peek;
 
     /** Some values we need to manage width on tablets */
@@ -152,14 +153,15 @@ public class BottomSheetLayout extends FrameLayout {
         dimView.setAlpha(0);
         dimView.setVisibility(INVISIBLE);
 
-        peek = 0;//getHeight() return 0 at start!
-
         setFocusableInTouchMode(true);
 
         Point point = new Point();
         ((WindowManager) getContext().getSystemService(Context.WINDOW_SERVICE)).getDefaultDisplay().getSize(point);
         screenWidth = point.x;
         sheetEndX = screenWidth;
+
+        peek = 0; //getHeight() return 0 at start!
+        peekKeyline = point.y - (screenWidth / (16.0f / 9.0f));
     }
 
     /**
@@ -480,7 +482,7 @@ public class BottomSheetLayout extends FrameLayout {
     }
 
     private boolean hasTallerKeylineHeightSheet() {
-        return getSheetView() == null || getSheetView().getHeight() > getPeekKeyline();
+        return getSheetView() == null || getSheetView().getHeight() > peekKeyline;
     }
 
     private boolean hasFullHeightSheet() {
@@ -550,14 +552,7 @@ public class BottomSheetLayout extends FrameLayout {
     }
 
     private float getDefaultPeekTranslation() {
-        return hasTallerKeylineHeightSheet() ? getPeekKeyline() : getSheetView().getHeight();
-    }
-
-    private float getPeekKeyline() {
-        final DisplayMetrics displayMetrics = getContext().getResources().getDisplayMetrics();
-        final int screenWidth = displayMetrics.widthPixels;
-        final int screenHeight = displayMetrics.heightPixels;
-        return screenHeight - (screenWidth / (16.0f / 9.0f));
+        return hasTallerKeylineHeightSheet() ? peekKeyline : getSheetView().getHeight();
     }
 
     /**

--- a/bottomsheet/src/main/java/com/flipboard/bottomsheet/BottomSheetLayout.java
+++ b/bottomsheet/src/main/java/com/flipboard/bottomsheet/BottomSheetLayout.java
@@ -12,6 +12,7 @@ import android.graphics.Rect;
 import android.os.Build;
 import android.support.annotation.NonNull;
 import android.util.AttributeSet;
+import android.util.DisplayMetrics;
 import android.util.Property;
 import android.view.Gravity;
 import android.view.KeyEvent;
@@ -478,6 +479,10 @@ public class BottomSheetLayout extends FrameLayout {
         }
     }
 
+    private boolean hasTallerKeylineHeightSheet() {
+        return getSheetView() == null || getSheetView().getHeight() > getPeekKeyline();
+    }
+
     private boolean hasFullHeightSheet() {
         return getSheetView() == null || getSheetView().getHeight() == getHeight();
     }
@@ -545,7 +550,14 @@ public class BottomSheetLayout extends FrameLayout {
     }
 
     private float getDefaultPeekTranslation() {
-        return hasFullHeightSheet() ? getHeight() / 3 : getSheetView().getHeight();
+        return hasTallerKeylineHeightSheet() ? getPeekKeyline() : getSheetView().getHeight();
+    }
+
+    private float getPeekKeyline() {
+        final DisplayMetrics displayMetrics = getContext().getResources().getDisplayMetrics();
+        final int screenWidth = displayMetrics.widthPixels;
+        final int screenHeight = displayMetrics.heightPixels;
+        return screenHeight - (screenWidth / (16.0f / 9.0f));
     }
 
     /**


### PR DESCRIPTION
According to the material design specs (https://material.google.com/components/bottom-sheets.html#bottom-sheets-specs)

> The initial height of a bottom sheet is relative to the height of the list items (or grid rows) it contains. A bottom sheet should not initially have a height beyond its 16:9 ratio keyline, depending on how much content it contains. Bottom sheets may be swiped up to fill the height of the screen, with content that then scrolls internally.

I noticed that the default height was simply set to `height / 3`, so this change makes it consistent with the guidelines, by defaulting to the 16:9 keyline.

btw I'm not happy with the function name `hasTallerKeylineHeightSheet` :) 