### PR TITLE
Fixed headers, changed tabs to spaces and fixed markdownlint warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#BottomSheet
+# BottomSheet
 
 [![Build Status](https://travis-ci.org/Flipboard/bottomsheet.svg)](https://travis-ci.org/Flipboard/bottomsheet) [![Join the chat at https://gitter.im/Flipboard/bottomsheet](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/Flipboard/bottomsheet?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
@@ -8,8 +8,10 @@ BottomSheet has been used in production at Flipboard for a while now so it is th
 
 ![FlipUI gif](http://i.imgur.com/2e3ZhoU.gif)
 
-##Installation
+## Installation
+
 If all you want is the BottomSheet component and don't need things from commons you can skip that dependency.
+
 ```groovy
 repositories {
     jcenter()
@@ -21,64 +23,70 @@ dependencies {
 }
 ```
 
-##Getting Started
+## Getting Started
+
 Get started by wrapping your layout in a `BottomSheetLayout`. So if you currently have this:
+
 ```xml
 <LinearLayout
-	android:id="@+id/root"
-	android:orientation="vertical"
-	android:layout_width="match_parent"
-	android:layout_height="match_parent">
+    android:id="@+id/root"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
 
-	<View
-		android:id="@+id/view1"
-		android:layout_width="match_parent"
-		android:layout_height="match_parent"/>
+    <View
+        android:id="@+id/view1"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"/>
 
 </LinearLayout>
 ```
 
 You would have to update it to look like this:
+
 ```xml
 <com.flipboard.bottomsheet.BottomSheetLayout
-	android:id="@+id/bottomsheet"
-	android:layout_width="match_parent"
-	android:layout_height="match_parent">
+    android:id="@+id/bottomsheet"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
 
-	<LinearLayout
-		android:id="@+id/root"
-		android:orientation="vertical"
-		android:layout_width="match_parent"
-		android:layout_height="match_parent">
+    <LinearLayout
+        android:id="@+id/root"
+        android:orientation="vertical"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
 
-		<View
-			android:id="@+id/view1"
-			android:layout_width="match_parent"
-			android:layout_height="match_parent"/>
+        <View
+            android:id="@+id/view1"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"/>
 
-	</LinearLayout>
+    </LinearLayout>
 
 </com.flipboard.bottomsheet.BottomSheetLayout>
 ```
 
 Back in your activity or fragment you would get a reference to the BottomSheetLayout like any other view.
+
 ```java
 BottomSheetLayout bottomSheet = (BottomSheetLayout) findViewById(R.id.bottomsheet);
 ```
 
 Now all you need to do is show a view in the bottomSheet:
+
 ```java
 bottomSheet.showWithSheetView(LayoutInflater.from(context).inflate(R.layout.my_sheet_layout, bottomSheet, false));
 ```
 
 You could also use one of the sheet views from the commons module.
+
 ```java
 bottomSheet.showWithSheetView(new IntentPickerSheetView(this, shareIntent, "Share with...", new IntentPickerSheetView.OnIntentPickedListener() {
-	@Override
-	public void onIntentPicked(IntentPickerSheetView.ActivityInfo activityInfo) {
+    @Override
+    public void onIntentPicked(IntentPickerSheetView.ActivityInfo activityInfo) {
         bottomSheet.dismissSheet();
-		startActivity(activityInfo.getConcreteIntent(shareIntent));
-	}
+        startActivity(activityInfo.getConcreteIntent(shareIntent));
+    }
 }));
 ```
 
@@ -86,46 +94,51 @@ That's it for the simplest of use cases. Check out the [API documentation](https
 
 For more examples, also see the [Recipes](https://github.com/Flipboard/bottomsheet/wiki/Recipes) wiki.
 
-##Common Components
+## Common Components
+
 These are located in the optional `bottomsheet-commons` dependency and implement common use cases for bottom sheet.
 
 Intent Picker | Menu Sheet | ImagePicker Sheet
 --- | --- | ---
 ![IntentPickerSheetView gif](http://i.imgur.com/wr9HJD1.gif) | ![MenuSheetView gif](http://i.imgur.com/f2j9Y5e.gif) | ![ImagePickerSheetView gif](https://camo.githubusercontent.com/23a9cf2bf9353a98d1b585e79d06639c7f5297c7/687474703a2f2f692e696d6775722e636f6d2f6f67764b4735692e676966)
 
-####IntentPickerSheetView
+### IntentPickerSheetView
+
 This component presents an intent chooser in the form of a BottomSheet view. Give it an intent such as a share intent and let the user choose what activity they want to share the intent with in a BottomSheet.
 
 Example from the sample app.
+
 ```java
 IntentPickerSheetView intentPickerSheet = new IntentPickerSheetView(MainActivity.this, shareIntent, "Share with...", new IntentPickerSheetView.OnIntentPickedListener() {
-	@Override
-	public void onIntentPicked(IntentPickerSheetView.ActivityInfo activityInfo) {
-		bottomSheet.dismissSheet();
-		startActivity(activityInfo.getConcreteIntent(shareIntent));
-	}
+    @Override
+    public void onIntentPicked(IntentPickerSheetView.ActivityInfo activityInfo) {
+        bottomSheet.dismissSheet();
+        startActivity(activityInfo.getConcreteIntent(shareIntent));
+    }
 });
 // Filter out built in sharing options such as bluetooth and beam.
 intentPickerSheet.setFilter(new IntentPickerSheetView.Filter() {
-	@Override
-	public boolean include(IntentPickerSheetView.ActivityInfo info) {
-		return !info.componentName.getPackageName().startsWith("com.android");
-	}
+    @Override
+    public boolean include(IntentPickerSheetView.ActivityInfo info) {
+        return !info.componentName.getPackageName().startsWith("com.android");
+    }
 });
 // Sort activities in reverse order for no good reason
 intentPickerSheet.setSortMethod(new Comparator<IntentPickerSheetView.ActivityInfo>() {
-	@Override
-	public int compare(IntentPickerSheetView.ActivityInfo lhs, IntentPickerSheetView.ActivityInfo rhs) {
-		return rhs.label.compareTo(lhs.label);
-	}
+    @Override
+    public int compare(IntentPickerSheetView.ActivityInfo lhs, IntentPickerSheetView.ActivityInfo rhs) {
+        return rhs.label.compareTo(lhs.label);
+    }
 });
 bottomSheet.showWithSheetView(intentPickerSheet);
 ```
 
-####MenuSheetView
+### MenuSheetView
+
 This component presents a BottomSheet view that's backed by a menu. It behaves similarly to the new `NavigationView` in the Design support library, and is intended to mimic the examples in the Material Design spec. It supports list and grid states, with the former adding further support for separators and subheaders.
 
 Example from the sample app.
+
 ```java
 MenuSheetView menuSheetView =
         new MenuSheetView(MenuActivity.this, MenuSheetView.MenuType.LIST, "Create...", new MenuSheetView.OnMenuItemClickListener() {
@@ -142,5 +155,6 @@ menuSheetView.inflateMenu(R.menu.create);
 bottomSheetLayout.showWithSheetView(menuSheetView);
 ```
 
-##Contributing
+## Contributing
+
 We welcome pull requests for bug fixes, new features, and improvements to BottomSheet. Contributors to the main BottomSheet repository must accept Flipboard's Apache-style [Individual Contributor License Agreement (CLA)](https://docs.google.com/forms/d/1gh9y6_i8xFn6pA15PqFeye19VqasuI9-bGp_e0owy74/viewform) before any changes can be merged.


### PR DESCRIPTION
Incidentally, the  **Individual Contributor License Agreement (CLA)** link towards the bottom of **README.md** is broken.

[Click here to see what the improved README looks like with proper headers](https://github.com/petterh/bottomsheet/tree/petterh/fix-readme).