### PR TITLE
Fix Landscape mode not working, update SupportLibraries(...) to v26, and update Glide to v4

### DIFF
--- a/bottomsheet-commons/build.gradle
+++ b/bottomsheet-commons/build.gradle
@@ -2,15 +2,16 @@ apply plugin: 'com.android.library'
 apply plugin: 'com.novoda.bintray-release'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion '23.0.2'
+    compileSdkVersion 26
+    buildToolsVersion '26.0.1'
 
     defaultConfig {
         minSdkVersion 14
-        targetSdkVersion 23
+        targetSdkVersion 26
     }
     lintOptions {
-          abortOnError false
+        abortOnError false
+        disable 'RestrictedApi'
     }
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_7
@@ -21,7 +22,7 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile project(':bottomsheet')
-    compile 'com.android.support:appcompat-v7:23.2.0'
+    compile 'com.android.support:appcompat-v7:26+'
 }
 
 publish {

--- a/bottomsheet-sample/build.gradle
+++ b/bottomsheet-sample/build.gradle
@@ -35,5 +35,5 @@ dependencies {
     compile project(':bottomsheet')
     compile project(':bottomsheet-commons')
     compile 'com.android.support:support-v4:26+'
-    compile 'com.github.bumptech.glide:glide:3.6.1'
+    compile 'com.github.bumptech.glide:glide:4.0.0'
 }

--- a/bottomsheet-sample/build.gradle
+++ b/bottomsheet-sample/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion '23.0.2'
+    compileSdkVersion 26
+    buildToolsVersion '26.0.1'
 
     defaultConfig {
         applicationId "com.flipboard.bottomsheet.sample"
         minSdkVersion 14
-        targetSdkVersion 23
+        targetSdkVersion 26
         versionCode 1
         versionName "1.0"
     }
@@ -34,6 +34,6 @@ dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile project(':bottomsheet')
     compile project(':bottomsheet-commons')
-    compile 'com.android.support:appcompat-v7:23.2.0'
+    compile 'com.android.support:support-v4:26+'
     compile 'com.github.bumptech.glide:glide:3.6.1'
 }

--- a/bottomsheet-sample/src/main/java/com/flipboard/bottomsheet/sample/ImagePickerActivity.java
+++ b/bottomsheet-sample/src/main/java/com/flipboard/bottomsheet/sample/ImagePickerActivity.java
@@ -19,6 +19,9 @@ import android.widget.ImageView;
 import android.widget.Toast;
 
 import com.bumptech.glide.Glide;
+import com.bumptech.glide.request.RequestOptions;
+import static com.bumptech.glide.load.resource.drawable.DrawableTransitionOptions.withCrossFade;
+
 import com.flipboard.bottomsheet.BottomSheetLayout;
 import com.flipboard.bottomsheet.R;
 import com.flipboard.bottomsheet.commons.ImagePickerSheetView;
@@ -100,10 +103,13 @@ public final class ImagePickerActivity extends AppCompatActivity {
                 .setImageProvider(new ImagePickerSheetView.ImageProvider() {
                     @Override
                     public void onProvideImage(ImageView imageView, Uri imageUri, int size) {
+                        RequestOptions options = new RequestOptions();
+                        options.centerCrop();
+
                         Glide.with(ImagePickerActivity.this)
                                 .load(imageUri)
-                                .centerCrop()
-                                .crossFade()
+                                .apply(options)
+                                .transition(withCrossFade())
                                 .into(imageView);
                     }
                 })
@@ -231,10 +237,14 @@ public final class ImagePickerActivity extends AppCompatActivity {
 
     private void showSelectedImage(Uri selectedImageUri) {
         selectedImage.setImageDrawable(null);
+
+        RequestOptions options = new RequestOptions();
+        options.fitCenter();
+
         Glide.with(this)
                 .load(selectedImageUri)
-                .crossFade()
-                .fitCenter()
+                .transition(withCrossFade())
+                .apply(options)
                 .into(selectedImage);
     }
 

--- a/bottomsheet/build.gradle
+++ b/bottomsheet/build.gradle
@@ -2,12 +2,12 @@ apply plugin: 'com.android.library'
 apply plugin: 'com.novoda.bintray-release'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion '23.0.2'
+    compileSdkVersion 26
+    buildToolsVersion '26.0.1'
 
     defaultConfig {
         minSdkVersion 14
-        targetSdkVersion 23
+        targetSdkVersion 26
     }
     lintOptions {
           abortOnError false
@@ -22,7 +22,7 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:support-v4:23.2.0'
+    compile 'com.android.support:support-v4:26+'
 }
 
 publish {

--- a/bottomsheet/src/main/java/com/flipboard/bottomsheet/BottomSheetLayout.java
+++ b/bottomsheet/src/main/java/com/flipboard/bottomsheet/BottomSheetLayout.java
@@ -12,6 +12,7 @@ import android.graphics.Rect;
 import android.os.Build;
 import android.support.annotation.NonNull;
 import android.util.AttributeSet;
+import android.util.DisplayMetrics;
 import android.util.Property;
 import android.view.Gravity;
 import android.view.KeyEvent;
@@ -159,8 +160,11 @@ public class BottomSheetLayout extends FrameLayout {
         screenWidth = point.x;
         sheetEndX = screenWidth;
 
+        DisplayMetrics metrics = getResources().getDisplayMetrics();
+        float ratio = ((float)metrics.heightPixels / (float)metrics.widthPixels);
+
         peek = 0; //getHeight() return 0 at start!
-        peekKeyline = point.y - (screenWidth / (16.0f / 9.0f));
+        peekKeyline = point.y * ratio;
     }
 
     /**

--- a/bottomsheet/src/main/java/com/flipboard/bottomsheet/BottomSheetLayout.java
+++ b/bottomsheet/src/main/java/com/flipboard/bottomsheet/BottomSheetLayout.java
@@ -164,7 +164,7 @@ public class BottomSheetLayout extends FrameLayout {
         float ratio = ((float)metrics.heightPixels / (float)metrics.widthPixels);
 
         peek = 0; //getHeight() return 0 at start!
-        peekKeyline = point.y * ratio;
+        peekKeyline = Math.min(point.y / ratio, point.y * ratio);
     }
 
     /**

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.0'
+        classpath 'com.android.tools.build:gradle:3.0.+'
         classpath 'com.novoda:bintray-release:0.5.0'
     }
 }
@@ -13,6 +13,7 @@ buildscript {
 allprojects {
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.1.0'
-        classpath 'com.novoda:bintray-release:0.3.4'
+        classpath 'com.novoda:bintray-release:0.5.0'
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue May 17 09:31:40 PDT 2016
+#Sat Aug 19 14:09:10 BRT 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.13-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-rc-1-all.zip


### PR DESCRIPTION
The most important change was at BottomSheetLayout.java where it was setting Peek to 0.0 in landscape mode, since there was a fault in the math. Now it also works flawless in Galaxy S8, LG G6 and other devices with a screen that is not 16:9. 
In e84455b, I fixed the Peek not showing in portrait mode;
In the last commit, I upgrade Gradle to the 3.0.0-beta2, in hope that Travis would work.