### PR TITLE
Fix wrong bottom sheet position after sheet gets expanded

### DIFF
--- a/bottomsheet/src/main/java/com/flipboard/bottomsheet/BottomSheetLayout.java
+++ b/bottomsheet/src/main/java/com/flipboard/bottomsheet/BottomSheetLayout.java
@@ -674,12 +674,16 @@ public class BottomSheetLayout extends FrameLayout {
             @Override
             public void onLayoutChange(View sheetView, int left, int top, int right, int bottom, int oldLeft, int oldTop, int oldRight, int oldBottom) {
                 int newSheetViewHeight = sheetView.getMeasuredHeight();
-                if (state != State.HIDDEN && newSheetViewHeight < currentSheetViewHeight) {
+                if (state != State.HIDDEN) {
                     // The sheet can no longer be in the expanded state if it has shrunk
-                    if (state == State.EXPANDED) {
+                    if (newSheetViewHeight < currentSheetViewHeight && state == State.EXPANDED) {
                         setState(State.PEEKED);
+                    } else if (newSheetViewHeight > currentSheetViewHeight && newSheetViewHeight == getMaxSheetTranslation() && state == State.PEEKED) {
+                        setState(State.EXPANDED);
                     }
-                    setSheetTranslation(newSheetViewHeight);
+                    if (newSheetViewHeight != currentSheetViewHeight) {
+                        setSheetTranslation(newSheetViewHeight);
+                    }
                 }
                 currentSheetViewHeight = newSheetViewHeight;
             }


### PR DESCRIPTION
We need to call setSheetTranslation after layout expand events as well as layout shrink