### PR TITLE
Fixes faulty bottom sheet position

### DIFF
--- a/bottomsheet/src/main/java/com/flipboard/bottomsheet/BottomSheetLayout.java
+++ b/bottomsheet/src/main/java/com/flipboard/bottomsheet/BottomSheetLayout.java
@@ -676,12 +676,15 @@ public class BottomSheetLayout extends FrameLayout {
                 int newSheetViewHeight = sheetView.getMeasuredHeight();
                 if (state != State.HIDDEN) {
                     // The sheet can no longer be in the expanded state if it has shrunk
-                    if (newSheetViewHeight < currentSheetViewHeight && state == State.EXPANDED) {
-                        setState(State.PEEKED);
-                    } else if (newSheetViewHeight > currentSheetViewHeight && newSheetViewHeight == getMaxSheetTranslation() && state == State.PEEKED) {
-                        setState(State.EXPANDED);
-                    }
-                    if (newSheetViewHeight != currentSheetViewHeight) {
+                    if (newSheetViewHeight < currentSheetViewHeight) {
+                        if (state == State.EXPANDED) {
+                            setState(State.PEEKED);
+                        }
+                        setSheetTranslation(newSheetViewHeight);
+                    } else if (currentSheetViewHeight > 0 && newSheetViewHeight > currentSheetViewHeight && state == State.PEEKED) {
+                        if (newSheetViewHeight == getMaxSheetTranslation()) {
+                            setState(State.EXPANDED);
+                        }
                         setSheetTranslation(newSheetViewHeight);
                     }
                 }


### PR DESCRIPTION
Caused by: https://github.com/Flipboard/bottomsheet/commit/c3d365a648b9c17d64e9$
Peek to expand case incorrectly triggered during bottomsheet's initial layout